### PR TITLE
[DASHBOARD] Fix chargement des données et template

### DIFF
--- a/src/app/features/dashboard/pages/home/home.component.html
+++ b/src/app/features/dashboard/pages/home/home.component.html
@@ -1,52 +1,28 @@
 <div class="dashboard-container">
   <h1>Tableau de bord</h1>
-  @if (isLoading) {
-    <app-loader>Chargement des données...</app-loader>
+
+  @if (isLoading()) {
+    <div class="loading-container">
+      <i class="pi pi-spin pi-spinner" style="font-size: 2rem"></i>
+    </div>
   }
-  
-  <div *ngIf="!isLoading" class="dashboard-cards">
-    <p-card styleClass="dashboard-card">
-      <ng-template pTemplate="header">
-        <div class="card-header">
-          <i class="pi pi-users"></i>
-          <h3>Utilisateurs</h3>
-        </div>
-      </ng-template>
-      <h2>{{ totalUsers }}</h2>
-      <a routerLink="/users">Voir les utilisateurs</a>
-    </p-card>
-    
-    <p-card styleClass="dashboard-card">
-      <ng-template pTemplate="header">
-        <div class="card-header">
-          <i class="pi pi-desktop"></i>
-          <h3>Bornes d'arcade</h3>
-        </div>
-      </ng-template>
-      <h2>{{ totalMachines }}</h2>
-      <a routerLink="/arcade-machines">Gérer les bornes</a>
-    </p-card>
-    
-    <p-card styleClass="dashboard-card">
-      <ng-template pTemplate="header">
-        <div class="card-header">
-          <i class="pi pi-play"></i>
-          <h3>Jeux</h3>
-        </div>
-      </ng-template>
-      <h2>{{ totalGames }}</h2>
-      <a routerLink="/games">Voir les jeux</a>
-    </p-card>
-    
-    <p-card styleClass="dashboard-card">
-      <ng-template pTemplate="header">
-        <div class="card-header">
-          <i class="pi pi-ticket"></i>
-          <h3>Parties en cours</h3>
-        </div>
-      </ng-template>
-      <h2>{{ activeParties }}</h2>
-      <a routerLink="/parties">Voir les parties</a>
-    </p-card>
-  </div>
+
+  @if (!isLoading()) {
+    <div class="dashboard-cards">
+      @for (card of dashboardCards(); track card.title) {
+        <p-card styleClass="dashboard-card">
+          <ng-template pTemplate="header">
+            <div class="card-header" [style.background-color]="card.color">
+              <i [class]="card.icon"></i>
+              <h3>{{ card.title }}</h3>
+            </div>
+          </ng-template>
+          <div class="card-body">
+            <h2>{{ card.value }}</h2>
+            <a [routerLink]="card.link">{{ card.linkText }}</a>
+          </div>
+        </p-card>
+      }
+    </div>
+  }
 </div>

--- a/src/app/features/dashboard/pages/home/home.component.ts
+++ b/src/app/features/dashboard/pages/home/home.component.ts
@@ -1,5 +1,3 @@
-// src/app/features/dashboard/pages/home/home.component.ts
-
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
@@ -9,8 +7,6 @@ import { ArcadesService } from '../../../../core/services/arcades.service';
 import { GamesService } from '../../../../core/services/games.service';
 import { UsersService } from '../../../../core/services/users.service';
 import { PartiesService } from '../../../../core/services/parties.service';
-import { LoaderComponent } from '../../../../shared/components/loader/loader.component';
-import { MachinesListComponent } from "../../../arcade-machines/pages/machines-list/machines-list.component";
 
 interface DashboardCard {
   title: string;
@@ -24,46 +20,15 @@ interface DashboardCard {
 @Component({
   selector: 'app-home',
   standalone: true,
-  imports: [CommonModule, RouterModule, CardModule, MachinesListComponent],
-  template: `
-    <div class="dashboard-container">
-      <h1>Tableau de bord</h1>
-      <app-machines-list></app-machines-list>
-      
-      @if (isLoading()) {
-        <div class="loading-container">
-          <!-- <app-loader size="large" message="Chargement des données..."></app-loader> -->
-        </div>
-      }
-      
-      <!-- @if (!isLoading()) {
-        <div class="dashboard-cards">
-          @for (card of dashboardCards(); track card.title) {
-            <p-card styleClass="dashboard-card">
-              <ng-template pTemplate="header">
-                <div class="card-header" [style.background-color]="card.color">
-                  <i [class]="card.icon"></i>
-                  <h3>{{ card.title }}</h3>
-                </div>
-              </ng-template>
-              <div class="card-body">
-                <h2>{{ card.value }}</h2>
-                <a [routerLink]="card.link">{{ card.linkText }}</a>
-              </div>
-            </p-card>
-          }
-        </div>
-      } -->
-    </div>
-  `,
+  imports: [CommonModule, RouterModule, CardModule],
+  templateUrl: './home.component.html',
   styleUrl: './home.component.scss'
 })
 export class HomeComponent implements OnInit {
-  // private readonly arcadesService = inject(ArcadesService);
-  // private readonly gamesService = inject(GamesService);
-  // private readonly usersService = inject(UsersService);
-  // private readonly partiesService = inject(PartiesService);
-  // private readonly promosService = inject(PromosService);
+  private readonly arcadesService = inject(ArcadesService);
+  private readonly gamesService = inject(GamesService);
+  private readonly usersService = inject(UsersService);
+  private readonly partiesService = inject(PartiesService);
 
   readonly isLoading = signal(true);
   readonly dashboardCards = signal<DashboardCard[]>([]);
@@ -72,68 +37,55 @@ export class HomeComponent implements OnInit {
     this.loadDashboardData();
   }
 
-  /**
-   * Charge les données du tableau de bord
-   */
   private loadDashboardData(): void {
     this.isLoading.set(true);
-    
+
     forkJoin({
-      // users: this.usersService.getAllUsers(),
-      // machines: this.arcadesService.getAllArcades(),
-      // games: this.gamesService.getAllGames(),
-      // activeParties: this.partiesService.getActiveParties()
+      users: this.usersService.getAllUsers(),
+      machines: this.arcadesService.getAllArcades(),
+      games: this.gamesService.getAllGames(),
+      activeParties: this.partiesService.getActiveParties()
     }).subscribe({
       next: (data) => {
-        this.updateDashboardCards(data);
+        this.dashboardCards.set([
+          {
+            title: 'Utilisateurs',
+            icon: 'pi pi-users',
+            value: data.users.length,
+            link: '/users',
+            linkText: 'Voir les utilisateurs',
+            color: 'var(--primary-color)'
+          },
+          {
+            title: "Bornes d'arcade",
+            icon: 'pi pi-desktop',
+            value: data.machines.length,
+            link: '/arcade-machines',
+            linkText: 'Gérer les bornes',
+            color: 'var(--green-500)'
+          },
+          {
+            title: 'Jeux',
+            icon: 'pi pi-play',
+            value: data.games.length,
+            link: '/games',
+            linkText: 'Voir les jeux',
+            color: 'var(--yellow-500)'
+          },
+          {
+            title: 'Parties en cours',
+            icon: 'pi pi-ticket',
+            value: data.activeParties.length,
+            link: '/parties',
+            linkText: 'Voir les parties',
+            color: 'var(--red-500)'
+          }
+        ]);
         this.isLoading.set(false);
       },
-      error: (error) => {
-        console.error('Error loading dashboard data:', error);
+      error: () => {
         this.isLoading.set(false);
       }
     });
-  }
-
-  /**
-   * Met à jour les cartes du tableau de bord
-   */
-  private updateDashboardCards(data: any): void {
-    const cards: DashboardCard[] = [
-      {
-        title: 'Utilisateurs',
-        icon: 'fas fa-users',
-        value: data.users.length,
-        link: '/users',
-        linkText: 'Voir les utilisateurs',
-        color: 'var(--primary-color)'
-      },
-      {
-        title: 'Bornes d\'arcade',
-        icon: 'fas fa-desktop',
-        value: data.machines.length,
-        link: '/arcade-machines',
-        linkText: 'Gérer les bornes',
-        color: 'var(--green-500)'
-      },
-      {
-        title: 'Jeux',
-        icon: 'fas fa-gamepad',
-        value: data.games.length,
-        link: '/games',
-        linkText: 'Voir les jeux',
-        color: 'var(--yellow-500)'
-      },
-      {
-        title: 'Parties en cours',
-        icon: 'fas fa-ticket',
-        value: data.activeParties.length,
-        link: '/parties',
-        linkText: 'Voir les parties',
-        color: 'var(--red-500)'
-      }
-    ];
-    
-    this.dashboardCards.set(cards);
   }
 }


### PR DESCRIPTION
- Décommente et injecte les 4 services (users, arcades, games, parties)
- Remplace le forkJoin vide par les vrais appels API en parallèle
- Migre le template inline vers home.component.html avec @if/@for
- Supprime l'import erroné de MachinesListComponent dans le dashboard
- Unifie les icônes en PrimeIcons (pi pi-*)