### PR TITLE
Fix/backoffice 16 promos edit regler bouton partager

### DIFF
--- a/src/app/features/promos/pages/promos-details/promos-details.component.html
+++ b/src/app/features/promos/pages/promos-details/promos-details.component.html
@@ -270,6 +270,7 @@
                 (click)="copyPromoCode()">
             </button>
             
+            <p-menu #shareMenu [model]="shareMenuItems" [popup]="true" appendTo="body"></p-menu>
             <button 
                 pButton 
                 pRipple 
@@ -278,7 +279,7 @@
                 severity="secondary"
                 outlined
                 class="action-btn"
-                (click)="sharePromoCode()">
+                (click)="shareMenu.toggle($event)">
             </button>
             
             @if (canActivate()) {

--- a/src/app/features/promos/pages/promos-details/promos-details.component.ts
+++ b/src/app/features/promos/pages/promos-details/promos-details.component.ts
@@ -12,7 +12,8 @@ import { ProgressBarModule } from 'primeng/progressbar';
 import { TimelineModule } from 'primeng/timeline';
 import { ChipModule } from 'primeng/chip';
 import { RippleModule } from 'primeng/ripple';
-import { MessageService } from 'primeng/api';
+import { MessageService, MenuItem } from 'primeng/api';
+import { MenuModule } from 'primeng/menu';
 import { PromosService } from '../../../../core/services/promos.service';
 import { PromoCode, PromoHistory } from '../../../../core/models/promo.model';
 import { LoaderComponent } from '../../../../shared/components/loader/loader.component';
@@ -106,7 +107,8 @@ class PromoDetailsStatsCalculator {
     ChipModule,
     RippleModule,
     LoaderComponent,
-    StatsCardComponent
+    StatsCardComponent,
+    MenuModule
   ],
   templateUrl: './promos-details.component.html',
   styleUrls: ['./promos-details.component.scss']
@@ -316,21 +318,53 @@ export class PromosDetailsComponent implements OnInit {
   }
   
   /**
-   * Partage le code promo
+   * Items du menu de partage
    */
-  protected sharePromoCode(): void {
+  protected readonly shareMenuItems: MenuItem[] = [
+    {
+      label: 'Partager via apps',
+      icon: 'pi pi-share-alt',
+      command: () => this.shareViaNative()
+    },
+    {
+      label: 'Envoyer par email',
+      icon: 'pi pi-envelope',
+      command: () => this.shareViaEmail()
+    }
+  ];
+
+  /**
+   * Partage natif (Web Share API) — WhatsApp, Teams, SMS...
+   */
+  protected shareViaNative(): void {
     const code = this.promo()?.code;
+    const tickets = this.promo()?.tickets_reward;
     if (!code) return;
-    
+
     if (navigator.share) {
       navigator.share({
         title: 'Code promo RetroNova',
-        text: `Utilisez le code ${code} pour obtenir ${this.promo()?.tickets_reward} tickets gratuits !`,
+        text: `Utilisez le code ${code} pour obtenir ${tickets} tickets gratuits sur RetroNova !`,
         url: window.location.href
-      });
+      }).catch(() => this.copyPromoCode());
     } else {
       this.copyPromoCode();
     }
+  }
+
+  /**
+   * Partage par email via mailto (corps maîtrisé)
+   */
+  protected shareViaEmail(): void {
+    const code = this.promo()?.code;
+    const tickets = this.promo()?.tickets_reward;
+    if (!code) return;
+
+    const subject = encodeURIComponent('Code promo RetroNova');
+    const body = encodeURIComponent(
+      `Utilisez le code ${code} pour obtenir ${tickets} tickets gratuits sur RetroNova !`
+    );
+    window.location.href = `mailto:?subject=${subject}&body=${body}`;
   }
   
   /**

--- a/src/app/features/promos/pages/promos-details/promos-details.component.ts
+++ b/src/app/features/promos/pages/promos-details/promos-details.component.ts
@@ -242,6 +242,7 @@ export class PromosDetailsComponent implements OnInit {
   });
   
   ngOnInit(): void {
+    this.buildShareMenu();
     const id = this.route.snapshot.paramMap.get('id');
     if (id) {
       this.promoId.set(+id);
@@ -320,36 +321,67 @@ export class PromosDetailsComponent implements OnInit {
   /**
    * Items du menu de partage
    */
-  protected readonly shareMenuItems: MenuItem[] = [
-    {
-      label: 'Partager via apps',
-      icon: 'pi pi-share-alt',
-      command: () => this.shareViaNative()
-    },
-    {
-      label: 'Envoyer par email',
-      icon: 'pi pi-envelope',
-      command: () => this.shareViaEmail()
-    }
-  ];
+  protected shareMenuItems: MenuItem[] = [];
 
   /**
-   * Partage natif (Web Share API) — WhatsApp, Teams, SMS...
+   * Construit dynamiquement le menu de partage selon les capacités de la plateforme
    */
-  protected shareViaNative(): void {
-    const code = this.promo()?.code;
-    const tickets = this.promo()?.tickets_reward;
-    if (!code) return;
+  private buildShareMenu(): void {
+    const items: MenuItem[] = [];
 
-    if (navigator.share) {
-      navigator.share({
-        title: 'Code promo RetroNova',
-        text: `Utilisez le code ${code} pour obtenir ${tickets} tickets gratuits sur RetroNova !`,
-        url: window.location.href
-      }).catch(() => this.copyPromoCode());
-    } else {
-      this.copyPromoCode();
-    }
+    // Partage web / liens directs qui ouvrent l'app si elle est installée
+    items.push(
+      { label: 'WhatsApp', icon: 'pi pi-whatsapp', command: () => this.shareToWhatsApp() },
+      { label: 'Facebook', icon: 'pi pi-facebook', command: () => this.shareToFacebook() },
+      { label: 'X (Twitter)', icon: 'pi pi-twitter', command: () => this.shareToX() },
+      { label: 'Gmail', icon: 'pi pi-envelope', command: () => this.shareToGmail() },
+      { label: 'Outlook', icon: 'pi pi-envelope', command: () => this.shareToOutlook() }
+    );
+
+    items.push({ separator: true }, { label: 'Envoyer par email', icon: 'pi pi-envelope', command: () => this.shareViaEmail() });
+
+    this.shareMenuItems = items;
+  }
+
+  private getShareText(): { text: string; url: string; subject: string } {
+    const code = this.promo()?.code || '';
+    const tickets = this.promo()?.tickets_reward ?? '';
+    const text = `Utilisez le code ${code} pour obtenir ${tickets} tickets gratuits sur RetroNova !`;
+    return { text, url: window.location.href, subject: 'Code promo RetroNova' };
+  }
+
+  protected shareToWhatsApp(): void {
+    const { text } = this.getShareText();
+    const encoded = encodeURIComponent(text);
+    window.open(`https://wa.me/?text=${encoded}`, '_blank');
+  }
+
+  protected shareToFacebook(): void {
+    const { text, url } = this.getShareText();
+    const q = encodeURIComponent(text);
+    const u = encodeURIComponent(url);
+    window.open(`https://www.facebook.com/sharer/sharer.php?u=${u}&quote=${q}`, '_blank');
+  }
+
+  protected shareToX(): void {
+    const { text, url } = this.getShareText();
+    const t = encodeURIComponent(text);
+    const u = encodeURIComponent(url);
+    window.open(`https://twitter.com/intent/tweet?text=${t}&url=${u}`, '_blank');
+  }
+
+  protected shareToGmail(): void {
+    const { text, subject } = this.getShareText();
+    const s = encodeURIComponent(subject);
+    const b = encodeURIComponent(text);
+    window.open(`https://mail.google.com/mail/?view=cm&fs=1&su=${s}&body=${b}`, '_blank');
+  }
+
+  protected shareToOutlook(): void {
+    const { text, subject } = this.getShareText();
+    const s = encodeURIComponent(subject);
+    const b = encodeURIComponent(text);
+    window.open(`https://outlook.live.com/owa/?path=/mail/action/compose&subject=${s}&body=${b}`, '_blank');
   }
 
   /**


### PR DESCRIPTION
Init avec version native mais ne fonctionne pas :
<img width="1917" height="1088" alt="Init-Promos-Edit-Ticket16 2026-03-04 104835" src="https://github.com/user-attachments/assets/3273cceb-fd2c-4880-9835-d63e1b0b4bb5" />

Changement:
<img width="1917" height="1091" alt="Changement-PROMOS-partage-Ticket16 2026-03-25 161644" src="https://github.com/user-attachments/assets/8d4aa95c-c240-4c7c-a2d4-5d7148edb295" />

<img width="1503" height="988" alt="Changement-PROMOS-partage2-Ticket16 2026-03-25 161923" src="https://github.com/user-attachments/assets/04276ae1-d55f-4074-beef-20ef60d8a738" />
